### PR TITLE
Fix tooltip artifact when locking screen

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -243,6 +243,9 @@ class WorkspacesBar extends PanelMenu.Button {
 		if (this.hide_tooltip_timeout) {
 			GLib.source_remove(this.hide_tooltip_timeout);
 		}
+		if (this.window_tooltip) {
+			this.window_tooltip.hide();
+		}
 		this.ws_bar.destroy();
 		super.destroy();
 	}


### PR DESCRIPTION
When locking a screen (with a keyboard shortcut) while hovering a
BaBar button, the extensions gets destroyed but the tooltip stays on,
effectively being orphaned and never getting hidden in the
future (even after unlocking the screen).